### PR TITLE
cache connections with host and username

### DIFF
--- a/lib/ftputils/ftpconnection.rb
+++ b/lib/ftputils/ftpconnection.rb
@@ -41,14 +41,15 @@ class FTPUtils
     def self.establish_connection(host, username, password, reload = false)
       self.connections ||= Hash.new
 
-      return connections[host] if connections[host] && !reload
+      connection_key = "#{username}@#{host}"
+      return connections[connection_key] if connections[connection_key] && !reload
 
       connection = Net::FTPFXP.new
       connection.passive = true
       connection.connect(host)
       connection.login(username, password) if username && password
 
-      connections[host] = connection
+      connections[connection_key] = connection
 
       return connection
     end


### PR DESCRIPTION
When we cache connections, we should cache the combination of host and username.
If `CustomerA` logs in with this tool to `vendor_ftp_host`, and now `CustomerB` also logs in with his own user to the same ftp host, `CustomerB` will get the cached ftp connection which actually belongs to `CustomerA`, which could become very dangerous. 
So it would be good to cache the combination of host and username instead of just the host.
